### PR TITLE
Change runner type from self-hosted to ubuntu-latest for overlooked file

### DIFF
--- a/.github/workflows/ruff.yml
+++ b/.github/workflows/ruff.yml
@@ -3,7 +3,7 @@ name: Linting (Ruff)
 on: [push, pull_request]
 jobs:
   ruff:
-    runs-on: self-hosted
+    runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
       - uses: astral-sh/ruff-action@v3


### PR DESCRIPTION
Extends a41a483041914037acb6bd2e7607f588ab6d64b5 and #10